### PR TITLE
Fixed QR code URL

### DIFF
--- a/lib/GoogleAuthenticator.php
+++ b/lib/GoogleAuthenticator.php
@@ -66,7 +66,7 @@ class GoogleAuthenticator {
     public function getUrl($user, $hostname, $secret) {
         $url =  sprintf("otpauth://totp/%s@%s?secret=%s", $user, $hostname, $secret);
         $encoder = "https://www.google.com/chart?chs=200x200&chld=M|0&cht=qr&chl=";
-        $encoderURL = sprintf( "%sotpauth://totp/%s@%s%%3Fsecret%%3D%s",$encoder, $user, $hostname, $secret);
+        $encoderURL = sprintf( "%sotpauth://totp/%s@%s&secret=%s",$encoder, $user, $hostname, $secret);
         
         return $encoderURL;
         


### PR DESCRIPTION
The URL for getting QR codes wasn't working.  The & and = were urlencoded and the google server didn't like that.  I replaced them with the actual characters where the URL is built and the QR code links seem to work great now.
