### PR TITLE
Update to getUrl() method

### DIFF
--- a/lib/GoogleAuthenticator.php
+++ b/lib/GoogleAuthenticator.php
@@ -63,13 +63,20 @@ class GoogleAuthenticator {
         return $val2[1];
     }
     
-    public function getUrl($user, $hostname, $secret) {
-        $url =  sprintf("otpauth://totp/%s@%s?secret=%s", $user, $hostname, $secret);
-        $encoder = "https://chart.googleapis.com/chart?chs=200x200&chld=M|0&cht=qr&chl=";
-        $encoderURL = sprintf( "%sotpauth://totp/%s@%s&secret=%s",$encoder, $user, $hostname, $secret);
-        
-        return $encoderURL;
-        
+    public function getUrl($user, $hostname, $secret, $size='200x200') {
+
+        $url = sprintf("otpauth://totp/%s@%s?secret=%s", $user, $hostname, $secret);
+
+        $base = 'https://chart.googleapis.com/chart';
+
+        $query = array(
+            'chs' => $size,
+            'chld' => 'M|0',
+            'cht' => 'qr',
+            'chl' => $url,
+        );
+
+        return $base.'?'.http_build_query($query);
     }
     
     public function generateSecret() {


### PR DESCRIPTION
Google seems to have changed the URI used for QR codes in the time since this class was written. I've fixed that. I also changed the function to use http_build_query as it handles any URI escaping that may be required.

I also added an optional $size argument in case the user wants a smaller or large QR code.
